### PR TITLE
add kubectl_get_secret_hash function for calculate external secret hash

### DIFF
--- a/kubernetes.sh
+++ b/kubernetes.sh
@@ -331,6 +331,9 @@ function kubectl_cp_container_of_first_running_pod () {
 	$KUBECTL cp -c $CONTAINER $KUBE_NAMESPACE/$POD:$DIR_FROM $DIR_TO
 }
 
+function kubectl_get_secret_hash () {
+  ${KUBECTL} -n ${KUBE_NAMESPACE} -o yaml get secret $1 | sha256sum | awk '{ print $1 }'
+}
 
 function helm_lock {
 	echo "NOTICE: Helm is parallel jobs safe now, you can safely remove helm_lock/helm_unlock calls"

--- a/tests/kubernetus.test.sh
+++ b/tests/kubernetus.test.sh
@@ -27,3 +27,15 @@ test_namespace_secret_acme_cert_with_acme_mode_docker_and_acme_account_cloudflar
 }
 
 test_namespace_secret_acme_cert_with_acme_mode_docker_and_acme_account_cloudflare
+
+
+test_kubectl_get_secret_hash () {
+  . ../kubernetes.sh
+
+  kube_cluster_login
+  export KUBE_NAMESPACE=default
+  kubectl_get_secret_hash example-secret
+
+}
+
+test_kubectl_get_secret_hash


### PR DESCRIPTION
Add hash in deployment for restart pod if in external secret change some filed 
```
# Source: workers/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
spec:
  template:
    metadata:
      annotations:
        externalSecretHash_foo: "sha256sum-value"

    spec:
      containers:
          envFrom:
            - secretRef:
                name: foo

```